### PR TITLE
Replace deprecated np.int

### DIFF
--- a/cryptorandom/sample.py
+++ b/cryptorandom/sample.py
@@ -112,7 +112,7 @@ def random_sample(a, size, replace=False, fast=False, p=None, method="sample_by_
 
     if replace is False and p is None:
         try:
-            sam = np.array(methods[method](N, size), dtype=np.int) - 1 # shift to 0 indexing
+            sam = np.array(methods[method](N, size), dtype=np.int64) - 1 # shift to 0 indexing
         except ValueError:
             print("Sampling method is incompatible with the inputs")
     elif replace is True and method in ['Fisher-Yates', 'PIKK', 'recursive',
@@ -120,12 +120,12 @@ def random_sample(a, size, replace=False, fast=False, p=None, method="sample_by_
         raise ValueError("Method is meant for sampling without replacement")
     elif replace is True and method in ['sample_by_index']:
         try:
-            sam = np.array(methods[method](N, size), dtype=np.int) - 1 # shift to 0 indexing
+            sam = np.array(methods[method](N, size), dtype=np.int64) - 1 # shift to 0 indexing
         except ValueError:
             print("Sampling method is incompatible with the inputs")
     else:
         try:
-            sam = np.array(methods[method](size, p), dtype=np.int) - 1
+            sam = np.array(methods[method](size, p), dtype=np.int64) - 1
         except ValueError:
             print("Sampling method is incompatible with the inputs")
     return a[sam]
@@ -241,7 +241,7 @@ def random_permutation(a, method="Fisher-Yates", prng=None):
     }
 
     try:
-        sam = np.array(methods[method](N), dtype=np.int) - 1 # shift to 0 indexing
+        sam = np.array(methods[method](N), dtype=np.int64) - 1 # shift to 0 indexing
     except ValueError:
         print("Bad permutation algorithm")
     return a[sam]
@@ -330,7 +330,7 @@ def recursive_sample(n, k, prng=None):
     '''
     prng = get_prng(prng)
     if k == 0:
-        return np.empty(0, dtype=np.int)
+        return np.empty(0, dtype=np.int64)
     else:
         S = recursive_sample(n-1, k-1, prng=prng)
         i = prng.randint(1, n+1)


### PR DESCRIPTION
@pbstark @akglazer I believe this is the last issue before we are ready to release new versions of cryptorandom and permute.  Let me know if my change makes sense or whether we should use something else to replace `np.int` (details below).

`np.int` is deprecated
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

You can read more in the above link, but this is the recommendation:
```
For np.int a direct replacement with np.int_ or int is also good and will not change behavior, but the precision will continue to depend on the computer and operating system. If you want to be more explicit and review the current use, you have the following alternatives:

- np.int64 or np.int32 to specify the precision exactly. This ensures that results cannot depend on the computer or operating system.
- np.int_ or int (the default), but be aware that it depends on the computer and operating system.
- The C types: np.cint (int), np.int_ (long), np.longlong.
- np.intp which is 32bit on 32bit machines 64bit on 64bit machines. This can be the best type to use for indexing.
```

I went with `np.int64`, but I am not sure that is what you want.  The advantage of using `np.int64` is that behavior should be consistent across computers/operating systems.  This shouldn't change behavior on Mac or Linux, but Windows will now use 64 bit integers (instead of 32 bit).